### PR TITLE
Automatically generate dbgsym packages

### DIFF
--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -133,6 +133,8 @@ for subpackage in ${config[Has_packages]} ; do
   
   # sub-package specific tests:
   debname=`echo ${name}_*.deb`
+  debug_name=`echo ${name}*dbgsym*_*.deb`
+  package_increment=1
   if [ $subpackage == "lib" ]; then
 
     # check for presence of .so file with the right name and version number in the pacakge
@@ -144,6 +146,14 @@ for subpackage in ${config[Has_packages]} ; do
     so_link=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}.so.${so_version_nopatch} -> lib${package}.so.${so_version}$"`
     if [ -z "$so_link" ]; then
       echo "Cannot find the link to the .so file in the library pacakge by the name: ./usr/lib/lib${package}.so.${so_version_nopatch}"
+      ERROR=1
+    fi
+
+    # There should be a debug package as well
+    debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+    package_increment=2
+    if [ "$debug_files" -lt 1 ]; then
+      echo "Debug package for doocs server is empty!"
       ERROR=1
     fi
 
@@ -223,12 +233,24 @@ for subpackage in ${config[Has_packages]} ; do
       fi
     done
 
+    # There should NOT be a debug package for this
+    if [ -e $debug_name ] ; then
+      echo "Unexpected debug file $debug_name found for development package"
+      ERROR=1
+    fi
+
   elif [ $subpackage == "doc" ]; then
 
     # check for presence of html files
     n_html_files=`dpkg -c $debname | grep -i "\./usr/share/doc/lib${package}${epoch_version}/html/.*\.html" | wc -l`
     if [ "$n_html_files" -lt 10 ]; then   # note, this is a quite arbitrary number!
       echo "Only $n_html_files html files found in the doc package! The validation expects at least 10 (which is arbitrary)."
+      ERROR=1
+    fi
+
+    # There should NOT be a debug package for this
+    if [ -e $debug_name ] ; then
+      echo "Unexpected debug file $debug_name found for doc package"
       ERROR=1
     fi
 
@@ -248,6 +270,14 @@ for subpackage in ${config[Has_packages]} ; do
       ERROR=1
     fi
 
+    # There should be a debug package as well
+    debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+    package_increment=2
+    if [ "$debug_files" -lt 1 ]; then
+      echo "Debug package for doocs server is empty!"
+      ERROR=1
+    fi
+
   elif [ $subpackage == "extra" ]; then
 
     # check for presence of files
@@ -262,6 +292,18 @@ for subpackage in ${config[Has_packages]} ; do
     if [ "$n_config_files" -gt 0 ]; then
       echo "The config script from the dev package was found in the extra package!"
       ERROR=1
+    fi
+
+    # May or may not have a debug package. If it has one, check for consistency
+    if [ -e "$debug_name" ] ; then
+      package_increment=2
+
+      # There should be a debug package as well
+      debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+      if [ "$debug_files" -lt 1 ]; then
+        echo "Debug package for doocs server is empty!"
+        ERROR=1
+      fi
     fi
 
   elif [ $subpackage == "python" ]; then
@@ -280,6 +322,18 @@ for subpackage in ${config[Has_packages]} ; do
       ERROR=1
     fi
 
+    # May or may not have a debug package. If it has one, check for consistency
+    if [ -e "$debug_name" ] ; then
+      package_increment=2
+
+      # There should be a debug package as well
+      debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+      if [ "$debug_files" -lt 1 ]; then
+        echo "Debug package for doocs server is empty!"
+        ERROR=1
+      fi
+    fi
+
   elif [ $subpackage == "doocs-bin" ]; then
 
     # check for presence of files in /export/doocs/server/...
@@ -288,7 +342,14 @@ for subpackage in ${config[Has_packages]} ; do
       echo "No files in the /export/doocs/server directory were found in the bin package!"
       ERROR=1
     fi
-    
+
+    # There should be a debug package as well
+    debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+    package_increment=2
+    if [ "$debug_files" -lt 1 ]; then
+      echo "Debug package for doocs server is empty!"
+      ERROR=1
+    fi
   else
   
     echo "Unknown sub-package type: $subpackage"
@@ -297,7 +358,7 @@ for subpackage in ${config[Has_packages]} ; do
   fi
   
   # increment checked number of files
-  nDebianFilesChecked=$(( nDebianFilesChecked + 1 ))
+  nDebianFilesChecked=$(( nDebianFilesChecked + package_increment ))
 
 done
 

--- a/publishDebianPackages
+++ b/publishDebianPackages
@@ -40,19 +40,25 @@ for package in "${!package_buildcmd[@]}"; do    # loop over all packages in the 
   BUILD_CONTROL_FILE=`echo ${package_buildcmd[$package]} | sed -e "s|^./makeDebianPackage |${WD}/|"`/control
   
   # obtain list of package names from the control file and form wildcards to match the deb files
-  TEMPFILE=`mktemp`
-  grep "^Package: " ${BUILD_CONTROL_FILE} | sed -e 's|^Package: ||g' > $TEMPFILE
-  PACKAGE_FILES_WILDCARDS_DEB=`cat $TEMPFILE | sed -e 's|$|_*.deb|g' | sed -e ':a;N;$!ba;s/\n/ /g'`
-  rm $TEMPFILE
-  
+  PACKAGE_FILES_WILDCARDS_DEB=$(awk 'BEGIN{ORS=" "} /^Package:/{print $2"_*.deb"}' ${BUILD_CONTROL_FILE})
+
+  # derive list of debug packages from this - they are not mentioned in the control files
+  PACKAGE_FILES_WILDCARDS_DBGSYM=$(awk 'BEGIN{ORS=" "} /^Package:/{print $2"-dbgsym_*.deb"}' ${BUILD_CONTROL_FILE})
+
+  # Filter dbgsym package names against available packages since they may or may not have been build
+  TMPPKG=""
+  for p in ${PACKAGE_FILES_WILDCARDS_DBGSYM} ; do
+      if ls ${p} >/dev/null 2>&1 ; then
+          TMPPKG="${TMPPKG} ${p}"
+      fi
+  done
+  PACKAGE_FILES_WILDCARDS_DBGSYM="${TMPPKG}"
+
   # obtain source package name from the control file and form wildcards to match the changes file
-  TEMPFILE=`mktemp`
-  grep "^Source: " ${BUILD_CONTROL_FILE} | sed -e 's|^Source: ||g' > $TEMPFILE
-  PACKAGE_FILES_WILDCARDS_CHANGES=`cat $TEMPFILE | sed -e 's|$|_*.changes|g' | sed -e ':a;N;$!ba;s/\n/ /g'`
-  rm $TEMPFILE
+  PACKAGE_FILES_WILDCARDS_CHANGES=$(awk 'BEGIN{ORS=" "} /^Source:/{print $2"_*.changes"}' ${BUILD_CONTROL_FILE})
 
   # merge the wildcards
-  PACKAGE_FILES_WILDCARDS="${PACKAGE_FILES_WILDCARDS_DEB} ${PACKAGE_FILES_WILDCARDS_CHANGES}"
+  PACKAGE_FILES_WILDCARDS="${PACKAGE_FILES_WILDCARDS_DEB} ${PACKAGE_FILES_WILDCARDS_CHANGES} ${PACKAGE_FILES_WILDCARDS_DBGSYM}"
   
 
   # obtain content of Target-repositories variable from CONFIG file
@@ -63,6 +69,7 @@ for package in "${!package_buildcmd[@]}"; do    # loop over all packages in the 
   # -- from the actual repository
   # This is done by writing a script, copying it to the InstallHost and executing it there.
   echo "${PACKAGE_FILES_WILDCARDS_DEB}"
+  echo "${PACKAGE_FILES_WILDCARDS_DBGSYM}"
   TEMPFILE=`mktemp -p .`
   echo "#!/bin/bash -e" > $TEMPFILE
   echo "cd ${PackageArchive}" >> $TEMPFILE
@@ -71,11 +78,21 @@ for package in "${!package_buildcmd[@]}"; do    # loop over all packages in the 
   echo "  echo mv \"\$p\" ../old" >> $TEMPFILE
   echo "  mv \"\$p\" ../old" >> $TEMPFILE
   echo "done" >> $TEMPFILE
-  echo "for p in ${PACKAGE_FILES_WILDCARDS_DEB}; do" >> $TEMPFILE
+  echo "for p in ${PACKAGE_FILES_WILDCARDS_DBGSYM}; do" >> $TEMPFILE
   echo "  if [ ! -f \"\$p\" ]; then continue ; fi" >> $TEMPFILE
+  echo "  packname=\`dpkg-deb -f \$p Package\`" >> $TEMPFILE
   echo "  echo mv \"\$p\" ../old" >> $TEMPFILE
   echo "  mv \"\$p\" ../old" >> $TEMPFILE
-  echo "  packname=\`echo \$p | sed -e 's|_.*\.deb$||'\`" >> $TEMPFILE
+  for REPO in ${TARGET_REPOSITORIES}; do
+    echo "  echo sudo -H reprepro --waitforlock 2 -Vb ${RepositoryDirectories[${REPO}]} remove ${distribution} \"\$packname\"" >> $TEMPFILE
+    echo "  sudo -H reprepro --waitforlock 2 -Vb ${RepositoryDirectories[${REPO}]} remove ${distribution} \"\$packname\"" >> $TEMPFILE
+  done
+  echo "done" >> $TEMPFILE
+  echo "for p in ${PACKAGE_FILES_WILDCARDS_DEB}; do" >> $TEMPFILE
+  echo "  if [ ! -f \"\$p\" ]; then continue ; fi" >> $TEMPFILE
+  echo "  packname=\`dpkg-deb -f \$p Package\`" >> $TEMPFILE
+  echo "  echo mv \"\$p\" ../old" >> $TEMPFILE
+  echo "  mv \"\$p\" ../old" >> $TEMPFILE
   for REPO in ${TARGET_REPOSITORIES}; do
     echo "  echo sudo -H reprepro --waitforlock 2 -Vb ${RepositoryDirectories[${REPO}]} remove ${distribution} \"\$packname\"" >> $TEMPFILE
     echo "  sudo -H reprepro --waitforlock 2 -Vb ${RepositoryDirectories[${REPO}]} remove ${distribution} \"\$packname\"" >> $TEMPFILE
@@ -92,7 +109,8 @@ for package in "${!package_buildcmd[@]}"; do    # loop over all packages in the 
 
   # Step 3: Install to the repository
   for REPO in ${TARGET_REPOSITORIES}; do
-      for FILE in ${PACKAGE_FILES_WILDCARDS_DEB}; do
+      PUBLISH_FILES_WILDCARDS="${PACKAGE_FILES_WILDCARDS_DEB} ${PACKAGE_FILES_WILDCARDS_DBGSYM}"
+      for FILE in ${PUBLISH_FILES_WILDCARDS} ; do
           ssh ${InstallHost} sudo -H reprepro --waitforlock 2 -Vb \
               ${RepositoryDirectories[${REPO}]} includedeb ${distribution} \
               ${PackageArchive}/${FILE}

--- a/templates/rules
+++ b/templates/rules
@@ -2,6 +2,11 @@
 ## Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
+export DH_BUILD_DDEBS=1
+
+DPKG_EXPORT_BUILDFLAGS=1
+include /usr/share/dpkg/default.mk
+
 # default action
 %:
 	dh $@ --parallel


### PR DESCRIPTION
This enables the following: 

- Building with "-g". It also enables -O2 but that will be overriden by the explicit -O3 in the CMakeFiles.txt
- Automatic creation of -dbgsym packages for all packages that contain binaries, e.g.

./binary-amd64/libbeam-arrival-time-monitor01-08-xenial19-dbgsym_01.08xenial19.02_amd64.deb
./binary-amd64/doocs-bam-server01-15-xenial2-dbgsym_01.15xenial2.01_amd64.deb
./binary-amd64/libmtca4u-motordrivercard01-04-xenial3-dbgsym_01.04xenial3.00_amd64.deb
./binary-amd64/mtca4u-motordrivercard-configcalculator-dbgsym_01.04xenial3.00_amd64.deb

The dbgsym mechanism of debian uses build-ids for the symbols, so they are parallel installable to the binaries itself.

I am not sure if those should go to the main repository as well, hence the PR