### PR TITLE
Add caveat about non-standard distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ sudo apt install pbuilder dh-make python-debian debhelper
 ```
 ### Recommendations
 
+#### Linux Distribution
+
+It is recommended to run this script on a standard Ubuntu installation. Non-standard distributions (such as the "yellow Linux" used on some DESY PCs) may break `pbuilder` / `debootstrap` by using apt sources / GPG keys different from the original.
+
 #### Kerberos
 Get valid kerberos tickets to `doocs.desy.de` and `doocspkgs.desy.de` before running the script. This avoids consecutive password prompts during the publishing step. The sequential password prompts give an impression of entered passwords being rejected and needing reentry (besides being inconvenient). Having a valid kerberos ticket sidesteps this issue. For a kerberos ticket:
 ```
@@ -136,3 +140,4 @@ Do you want to proceed with configuring and building the packages in the given v
 ```
 
 The package `dev-doocswrappers` is a reverse depenency of DOOCS, but it cannot be built using the ChimeraTK packaging scripts. This package would have to be updated manually (if it wasn't an obsolete, leftover library).
+


### PR DESCRIPTION
Warn users about potential stuff like this:

<pre>$ ./master focal qthardmon 01.04.00
X11 forwarding request failed on channel 0
Searching for reverse dependencies...
Verifying versions...
Sorting package list...

The following packages will be built (in that order):
qthardmon 01.04.00

Do you want to proceed with configuring and building the packages in the given versions (y/N)? y
[sudo] password for huesmann: 
We have root rights now.

<font color="#3465A4"><b>Configuring qthardmon in version 01.04.00 for focal...</b></font>
gpgv: Signature made Tue Jul 20 06:38:46 2021 CEST
W: /root/.pbuilderrc does not exist0E60CA794E76CE0E
<font color="#C4A000"><b>W: cgroups are not available on the host, not using them.</b></font>
I: Distribution is focal.
I: Current time: Tue Jul 20 17:42:57 CEST 2021
I: pbuilder-time-stamp: 1626795777
I: Building the build environment
I: running debootstrap
/usr/sbin/debootstrap
I: Retrieving InRelease 
I: Checking Release signature
E: Release signed by unknown key (key id 0E60CA794E76CE0E)
   The specified keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg may be incorrect or out of date.
   You can find the latest Debian release key at https://ftp-master.debian.org/keys.html
<font color="#CC0000">E: debootstrap failed</font>
<font color="#CC0000">E: Tail of debootstrap.log:</font>
2021-07-20 17:42:57 URL:http://nims.desy.de/extra/desy/dists/focal/InRelease [15867/15867] -&gt; &quot;/var/cache/pbuilder/build/508512/var/lib/apt/lists/partial/nims.desy.de_extra_desy_dists_focal_InRelease&quot; [1]
gpgv: Signature made Tue Jul 20 06:38:46 2021 CEST
gpgv:                using RSA key 0E60CA794E76CE0E
gpgv: Can&apos;t check signature: No public key
<font color="#CC0000">E: End of debootstrap.log</font>
<font color="#C4A000"><b>W: Aborting with an error</b></font>
</pre>