### PR TITLE
Fail gracefully if doocspkgs.desy.de is not accessible

### DIFF
--- a/findReverseDependencies
+++ b/findReverseDependencies
@@ -43,6 +43,16 @@ def resolvePackagePattern(packagePattern, Packages):
 
   return resolvedPackages
 
+def subprocessHelper(argList):
+  cmd_cmplt = subprocess.run(
+      argList,
+      capture_output=True,
+  )
+  if cmd_cmplt.returncode != 0:
+      stdout_msg = cmd_cmplt.stdout.decode('utf-8')
+      stderr_msg = cmd_cmplt.stderr.decode('utf-8')
+      raise RuntimeError(f'{argList} failed:\n{stdout_msg}\n{stderr_msg}')
+
 def main():
     # output usage
     if len(sys.argv) != 4 and len(sys.argv) != 5 :
@@ -62,9 +72,14 @@ def main():
       arch = "amd64"
     
     # download Packages file from the DESY DOOCS apt repositories
-    subprocess.call(["wget", "-q", debianrepository+"/pub/doocs/dists/"+codename+"/main/binary-"+arch+"/Packages", "-O", "Packages.DESY"])
-    subprocess.call(["mv","Packages.DESY","TMP.DESY"])
-    subprocess.call(["iconv", "-c", "-t", "UTF-8", "TMP.DESY","-o","Packages.DESY"])
+    try:
+      subprocessHelper(["wget", "-q", debianrepository+"/pub/doocs/dists/"+codename+"/main/binary-"+arch+"/Packages", "-O", "Packages.DESY"])
+    except RuntimeError:
+      raise RuntimeError(f'wget from {debianrepository} failed; are you in DESY network?')
+
+    subprocessHelper(["mv","Packages.DESY","TMP.DESY"])
+    subprocessHelper(["iconv", "-c", "-t", "UTF-8", "TMP.DESY","-o","Packages.DESY"])
+
     # open Packages file and parse it
     PackageFile = debian.debian_support.PackageFile("Packages.DESY")
     Packages = []

--- a/master
+++ b/master
@@ -191,7 +191,10 @@ echo "Searching for reverse dependencies..."
 for package in "${!package_list[@]}"; do
   # obtain possible reverse dependencies for lib${package}-dev
   TEMPFILE=`mktemp`
-  ./findReverseDependencies lib${package}-dev $distribution $DebianRepository $arch | grep "^lib" | grep -- "-dev " | sed -e 's/^lib//' -e 's/-dev / /' > $TEMPFILE
+  # Let 'set -e' check if 'findReverseDependencies' fails; don't care about the rest of the pipeline
+  # (Cannot use 'set -o pipefail', as that would break other stuff in this script)
+  DEPENDENCIES_RESULT=$(./findReverseDependencies lib${package}-dev $distribution $DebianRepository $arch)
+  echo "${DEPENDENCIES_RESULT}" | grep "^lib" | grep -- "-dev " | sed -e 's/^lib//' -e 's/-dev / /' > $TEMPFILE
   readarray revdeps_with_versions < $TEMPFILE
   rm -f $TEMPFILE
   # loop over any found reverse dependencies


### PR DESCRIPTION
If `doocspkgs.desy.de` is not accessible (e.g. when outside of DESY network), the script prints out a rather vague error message (see below) and tries to proceed building the package, eventually failing on missing dependencies.

This patch improves the user experience by aborting early and printing out a meaningful error message if download/creation of `Packages.DESY` fails.

<pre>$ ./master focal qthardmon 01.04.00                            
Searching for reverse dependencies...
Traceback (most recent call last):
  File &quot;./findReverseDependencies&quot;, line 86, in &lt;module&gt;
    main()
  File &quot;./findReverseDependencies&quot;, line 69, in main
    PackageFile = debian.debian_support.PackageFile(&quot;Packages.DESY&quot;)
  File &quot;/usr/lib/python3/dist-packages/debian/debian_support.py&quot;, line 390, in __init__
    file_obj = open(name, &apos;rb&apos;)
FileNotFoundError: [Errno 2] No such file or directory: &apos;Packages.DESY&apos;
Verifying versions...
Sorting package list...

The following packages will be built (in that order):
qthardmon 01.04.00
(...)
</pre>