### PR TITLE
Fix version comparison.

### DIFF
--- a/configureRelease
+++ b/configureRelease
@@ -49,20 +49,6 @@ class ExceptionHandlingIterator(object):
         except Exception as e:
             return self.__next__()
 
-def compareVersion(versionA, versionB):
-  '''
-  Compare two version strings, e.g. 0.09focal11.03-0 00.09focal5.01-00 will give True.
-  @param versionA(str): Version to test.
-  @param versionB(str): Version to compare to.
-  
-  @return: True if versionA is more up to date compared to versionB.
-  ''' 
-  try:
-    return parseVersion(versionA) > parseVersion(versionB)
-  except KeyError:
-    print("Warning: Version comparison failed for: {} < {}".format(versionA, versionB))
-    return False
-
 # function for resolving dependencies from a Packages file
 # returns a dictionary: "name" -> "version"
 def resolveDeps(dependencies, filename):
@@ -80,13 +66,13 @@ def resolveDeps(dependencies, filename):
     for dependency in dependencies:
       PackageAsDictionary = dict(Package)
       if dependency == PackageAsDictionary["Package"]:
-        if not dependency in dependency_versions.keys() or compareVersion(PackageAsDictionary["Version"], dependency_versions[dependency]):
+        if not dependency in dependency_versions.keys() or parseVersion(PackageAsDictionary["Version"]) > parseVersion(dependency_versions[dependency]):
           dependency_versions[dependency] = PackageAsDictionary["Version"]
           map_virtual_to_real[dependency] = PackageAsDictionary["Package"]
 
       if "Provides" in PackageAsDictionary.keys() :
         if dependency == PackageAsDictionary["Provides"]:
-          if not dependency in dependency_versions.keys() or compareVersion(PackageAsDictionary["Version"], dependency_versions[dependency]):
+          if not dependency in dependency_versions.keys() or parseVersion(PackageAsDictionary["Version"]) > parseVersion(dependency_versions[dependency]):
             dependency_versions[dependency] = PackageAsDictionary["Version"]
             map_virtual_to_real[dependency] = PackageAsDictionary["Package"]
 

--- a/configureRelease
+++ b/configureRelease
@@ -14,6 +14,8 @@ import datetime
 debianCodenames=['jessie','buster','stretch','bullseye']
 import argparse
 
+from packaging.version import parse as parseVersion
+
 def extract_tokens(input_string):
   """
   returns a list of all keywords from input_string
@@ -47,6 +49,20 @@ class ExceptionHandlingIterator(object):
         except Exception as e:
             return self.__next__()
 
+def compareVersion(versionA, versionB):
+  '''
+  Compare two version strings, e.g. 0.09focal11.03-0 00.09focal5.01-00 will give True.
+  @param versionA(str): Version to test.
+  @param versionB(str): Version to compare to.
+  
+  @return: True if versionA is more up to date compared to versionB.
+  ''' 
+  try:
+    return parseVersion(versionA) > parseVersion(versionB)
+  except KeyError:
+    print("Warning: Version comparison failed for: {} < {}".format(versionA, versionB))
+    return False
+
 # function for resolving dependencies from a Packages file
 # returns a dictionary: "name" -> "version"
 def resolveDeps(dependencies, filename):
@@ -64,13 +80,13 @@ def resolveDeps(dependencies, filename):
     for dependency in dependencies:
       PackageAsDictionary = dict(Package)
       if dependency == PackageAsDictionary["Package"]:
-        if not dependency in dependency_versions.keys() or PackageAsDictionary["Version"] > dependency_versions[dependency]:
+        if not dependency in dependency_versions.keys() or compareVersion(PackageAsDictionary["Version"], dependency_versions[dependency]):
           dependency_versions[dependency] = PackageAsDictionary["Version"]
           map_virtual_to_real[dependency] = PackageAsDictionary["Package"]
 
       if "Provides" in PackageAsDictionary.keys() :
         if dependency == PackageAsDictionary["Provides"]:
-          if not dependency in dependency_versions.keys() or PackageAsDictionary["Version"] > dependency_versions[dependency]:
+          if not dependency in dependency_versions.keys() or compareVersion(PackageAsDictionary["Version"], dependency_versions[dependency]):
             dependency_versions[dependency] = PackageAsDictionary["Version"]
             map_virtual_to_real[dependency] = PackageAsDictionary["Package"]
 

--- a/master
+++ b/master
@@ -43,7 +43,7 @@ if ! which dh_make > /dev/null ; then
   exit 1
 fi
 # check for Python module packaging used in configureRelease for version comparison
-if ! python3 -m packagisng.version > /dev/null ; then
+if ! python3 -m packaging.version > /dev/null ; then
   echo "ERROR: python package 'packaging' not found."
   echo "  pip3 install packaging"
   exit 1

--- a/master
+++ b/master
@@ -45,6 +45,8 @@ fi
 # check for Python module packaging used in configureRelease for version comparison
 if ! python3 -m packaging.version > /dev/null ; then
   echo "ERROR: python package 'packaging' not found."
+  echo "  sudo apt install python3-packaging"
+  echo "  or using pip3:"
   echo "  pip3 install packaging"
   exit 1
 fi  

--- a/master
+++ b/master
@@ -35,12 +35,19 @@ function showHelp() {
   echo "Specifying 'latest' as a version will build the greatest version (see sort -V) found on the source repository."
 }
 
-# check prerequisites
+## check prerequisites ##
+# check for dh_make
 if ! which dh_make > /dev/null ; then
   echo "ERROR: dh_make was not found. Please install it first by running:"
   echo "  sudo apt install dh-make"
   exit 1
 fi
+# check for Python module packaging used in configureRelease for version comparison
+if ! python3 -m packagisng.version > /dev/null ; then
+  echo "ERROR: python package 'packaging' not found."
+  echo "  pip3 install packaging"
+  exit 1
+fi  
 
 use_preseed_repository=0
 # check command line arguments


### PR DESCRIPTION
So far the version comparison fails for patch versions greater 9, e.g.
```
(Pdb) print(PackageAsDictionary["Version"] > dependency_versions[dependency])
True
(Pdb) print(PackageAsDictionary["Version"])
00.09focal5.01-0
(Pdb) print(dependency_versions[dependency])
00.09focal11.03-0
```

Fixed by using `packaging.version` Python module to parse the version number. I also added a check to the master script to check if `packaging` is available.