### PR TITLE
Add security repos right from the beginning.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -48,6 +48,17 @@ if [ "${distribution}" == "buster" ] || [ "${distribution}" == "stretch"  ]; the
 	ADDITIONALREPO="contrib"
 fi
 
+# This list is used when the pbuilder image is build the first time. 
+# It was introduced to install ca-certificates needed to use the DESY repository later on 
+INITIALPACKAGESLIST=""
+# This list adds extra mirrors added initialy when the pbuilder image is created
+INITIALEXTRAMIRROR=""
+
+if [ "${distribution}" == "focal" ]; then
+  INITIALPACKAGESLIST = "apt-transport-https ca-certificates gnupg software-properties-common wget"
+  INITIALEXTRAMIRROR = "deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-updates main universe|deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-security main universe"
+fi
+
 # Override configuration
 if [ -d "${WD}/override_config" ]; then
     echo "Found directory 'override_config'. Loading additional config.sh"

--- a/updatePBuilder
+++ b/updatePBuilder
@@ -39,7 +39,7 @@ mkdir -p "${LOCAL_REPOS}"
 
 # if image does not exist, create it first
 if [ ! -f ${PBUILDER_IMAGE} ]; then
-  sudo pbuilder --create --distribution $DISTRIBUTION --basetgz "${PBUILDER_IMAGE}" || exit 1
+  sudo pbuilder --create --distribution $DISTRIBUTION --basetgz "${PBUILDER_IMAGE}" --extrapackages "apt-transport-https ca-certificates gnupg software-properties-common wget" --basetgz "${PBUILDER_IMAGE}" --othermirror "deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-updates main universe|deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-security main universe"|| exit 1
 
   # Execute a script inside the pbuilder chroot environment to set it up properly for our needs:
   # - Make sure the local package repository gets priority. Not sure how this works and if it's realy correct. Found

--- a/updatePBuilder
+++ b/updatePBuilder
@@ -39,7 +39,7 @@ mkdir -p "${LOCAL_REPOS}"
 
 # if image does not exist, create it first
 if [ ! -f ${PBUILDER_IMAGE} ]; then
-  sudo pbuilder --create --distribution $DISTRIBUTION --basetgz "${PBUILDER_IMAGE}" --extrapackages "apt-transport-https ca-certificates gnupg software-properties-common wget" --basetgz "${PBUILDER_IMAGE}" --othermirror "deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-updates main universe|deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-security main universe"|| exit 1
+  sudo pbuilder --create --distribution $DISTRIBUTION --basetgz "${PBUILDER_IMAGE}" --extrapackages "${INITIALPACKAGESLIST}" --basetgz "${PBUILDER_IMAGE}" --othermirror "${INITIALEXTRAMIRROR}"|| exit 1
 
   # Execute a script inside the pbuilder chroot environment to set it up properly for our needs:
   # - Make sure the local package repository gets priority. Not sure how this works and if it's realy correct. Found


### PR DESCRIPTION
When calling the master script at some point the additional mirrors (including security repos) are added together with the doocs repository. At this point the update of apt fails because the public desy repository requires a newer version of ca-certificates. The version installed so far from `deb http://archive.ubuntu.com/ubuntu/ focal main universe` is too old.

Now the security repos are added right from the beginning together with `ca-certificates` and related packages. Thus an up to date version of  `ca-certificates` is installed and later an update of apt including the desy repository is successful. 