### PR TITLE
Wip/10564 add dynload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ $ export N_PBUILDER_THREADS=5
 ```
 ## Usage
 
-Run the master script with the distibution you want to build for, and the (debian) package name and the version you want to build for.
+Run the master script with the distribution you want to build for, and the (debian) package name and the version you want to build for.
 
 Currently available and tested Ubuntu releases are
 
 * `xenial` = Ubuntu 16.04
 * `focal` = Ubuntu 20.04
 
-The system uses pbuilder, which allows you to build packages also for other Ubuntu releases. Currently the host system has to be Ubuntu 18.04 or newer, if you want to build for focal. You need root privileges to run pbuilder and you need write permissions to the ChimeraTK DebianBuildVersions repository and the doocspkgs host.
+The system uses pbuilder, which allows you to build packages also for other Ubuntu releases. Currently, the host system has to be Ubuntu 18.04 or newer, if you want to build for focal. You need root privileges to run pbuilder and you need write permissions to the ChimeraTK DebianBuildVersions repository and the doocspkgs host.
 
 Syntax:
 
@@ -87,15 +87,13 @@ copy of this repository. The additional file will be sourced at the end of the
 default one.
 
 ### Preseeding
-
-In rare conditions it might be necessary to build against an older set of development packages than what is available in the official repositories.
-In that case it is possible to put the relevant packages into a repository structure below the `preseed` folder.
+In rare conditions, it might be necessary to build against an older set of development packages than what is available in the official repositories.
+In that case, it is possible to put the relevant packages into a repository structure below the `preseed` folder.
 
 The `master` script has to be called with the parameter `--preseed` for the packaging scripts to pack them up
 
 ### Additional tweaks
-
-During package development it might be that you have a high turn-around in calling the master script. To accomodate this, it is possible to skip or speed up certain parts of the process:
+During package development, it might be that you have a high turn-around in calling the master script. To accommodate this, it is possible to skip or speed up certain parts of the process:
 
 #### Skipping the initial pbuilder update
 

--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -113,9 +113,9 @@ for subpackage in ${config[Has_packages]} ; do
     package_suffix=""
     if [ $subpackage == "dev" -o $subpackage == "doc" -o $subpackage == "extra" -o $subpackage == "extra2" ]; then
       package_suffix="-$subpackage"
-    elif [ $subpackage == "dev-noheader" -o $subpackage == "dev-headeronly" -o $subpackage == "dev-alien" ]; then
+    elif [ $subpackage == "dev-noheader" -o $subpackage == "dev-headeronly" -o $subpackage == "dev-alien" -o $subpackage == "dev-noheader-dynload" ]; then
       package_suffix="-dev"
-    elif [ $subpackage == "python" ]; then
+    elif [ $subpackage == "python" -o $subpackage == "dynload" ]; then
       package_suffix=""
     else
       if [ "${config[package_name_contains_buildversion]}" == "1" ]; then
@@ -193,7 +193,7 @@ for subpackage in ${config[Has_packages]} ; do
       ERROR=1
     fi
 
-  elif [ $subpackage == "dev" -o $subpackage == "dev-noheader" -o $subpackage == "dev-headeronly" -o $subpackage == "dev-alien" ]; then
+  elif [ $subpackage == "dev" -o $subpackage == "dev-noheader" -o $subpackage == "dev-headeronly" -o $subpackage == "dev-alien"  -o $subpackage == "dev-noheader-dynload"  -o $subpackage == "dynload" ]; then
 
     # check for presence of include files
     if [ $subpackage == "dev" -o $subpackage == "dev-headeronly" -o $subpackage == "dev-alien" ]; then
@@ -204,22 +204,24 @@ for subpackage in ${config[Has_packages]} ; do
       fi
     fi
 
-    # check for presence of -config script
-    n_config_files=`dpkg -c $debname | grep "\./usr/bin/.*-config" | wc -l`
-    if [ "$n_config_files" -ne 1 -a $subpackage != "dev-alien" ]; then
-      echo "Did not find the config script required for a dev package!"
-      ERROR=1
-    fi
-
-    # check for presence of cmake find package macro
-    n_config_files=`dpkg -c $debname | grep "\./usr/share/cmake-.*/Modules/Find.*\.cmake" | wc -l`
-    if [ "$n_config_files" -lt 1 -a $subpackage != "dev-alien" ]; then
-      echo "Did not find the cmake find_package macro!"
-      ERROR=1
+    if [ $subpackage != "dynload" ]; then
+      # check for presence of -config script
+      n_config_files=`dpkg -c $debname | grep "\./usr/bin/.*-config" | wc -l`
+      if [ "$n_config_files" -ne 1 -a $subpackage != "dev-alien" ]; then
+        echo "Did not find the config script required for a dev package!"
+        ERROR=1
+      fi
+    
+      # check for presence of cmake find package macro
+      n_config_files=`dpkg -c $debname | grep "\./usr/share/cmake-.*/Modules/Find.*\.cmake" | wc -l`
+      if [ "$n_config_files" -lt 1 -a $subpackage != "dev-alien" ]; then
+        echo "Did not find the cmake find_package macro!"
+        ERROR=1
+      fi
     fi
 
     # check for presence of so link
-    if [ $subpackage == "dev" -o $subpackage == "dev-noheader" ]; then
+    if [ $subpackage == "dev" -o $subpackage == "dev-noheader" -o $subpackage == "dynload" ]; then
       so_link=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}\.so -> lib${package}\.so\.${so_version_nopatch}$"`
       if [ -z "$so_link" ]; then
         echo "Cannot find the link to the .so file in the dev pacakge by the name: ./usr/lib/lib${package}.so"

--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -100,6 +100,14 @@ for subpackage in ${config[Has_packages]} ; do
   fi
 done
 
+# check if we have the dev-noheader-dynload sub-package, in which case we need add a dynload package as well
+for subpackage in ${config[Has_packages]} ; do
+  if [ $subpackage == "dev-noheader-dynload" ]; then
+    config[Has_packages]+=" dynload"
+    break
+  fi
+done
+
 # loop over the sub-packages
 for subpackage in ${config[Has_packages]} ; do
   echo " -> subpackage: $subpackage"

--- a/configureRelease
+++ b/configureRelease
@@ -132,6 +132,7 @@ config["Dependencies-python"] = ""
 config["Install-additional-pattern-dev"] = ""
 
 config["Conflicts-lib"] = ""
+config["Conflicts-dynload"] = ""
 config["Conflicts-dev"] = ""
 config["Conflicts-bin"] = ""
 config["Conflicts-extra"] = ""
@@ -140,6 +141,7 @@ config["Conflicts-python"] = ""
 config["Conflicts-doc"] = ""
 
 config["Replaces-lib"] = ""
+config["Replaces-dynload"] = ""
 config["Replaces-dev"] = ""
 config["Replaces-bin"] = ""
 config["Replaces-extra"] = ""
@@ -148,6 +150,7 @@ config["Replaces-python"] = ""
 config["Replaces-doc"] = ""
 
 config["Breaks-lib"] = ""
+config["Breaks-dynload"] = ""
 config["Breaks-dev"] = ""
 config["Breaks-bin"] = ""
 config["Breaks-extra"] = ""
@@ -156,6 +159,7 @@ config["Breaks-python"] = ""
 config["Breaks-doc"] = ""
 
 config["Enhances-lib"] = ""
+config["Enhances-dynload"] = ""
 config["Enhances-dev"] = ""
 config["Enhances-bin"] = ""
 config["Enhances-extra"] = ""
@@ -164,6 +168,7 @@ config["Enhances-python"] = ""
 config["Enhances-doc"] = ""
 
 config["Suggests-lib"] = ""
+config["Suggests-dynload"] = ""
 config["Suggests-dev"] = ""
 config["Suggests-bin"] = ""
 config["Suggests-extra"] = ""
@@ -172,6 +177,7 @@ config["Suggests-python"] = ""
 config["Suggests-doc"] = ""
 
 config["Recommends-lib"] = ""
+config["Recommends-dynload"] = ""
 config["Recommends-dev"] = ""
 config["Recommends-bin"] = ""
 config["Recommends-extra"] = ""
@@ -180,6 +186,7 @@ config["Recommends-python"] = ""
 config["Recommends-doc"] = ""
 
 config["Provides-lib"] = ""
+config["Provides-dynload"] = ""
 config["Provides-dev"] = ""
 config["Provides-bin"] = ""
 config["Provides-extra"] = ""
@@ -252,6 +259,8 @@ if not "Package-name-dev" in config:
   config["Package-name-dev"] = config["package-basename"]+"-dev"
 if not "Package-name-dev-noheader" in config:
   config["Package-name-dev-noheader"] = config["Package-name-dev"]
+if not "Package-name-dev-noheader-dynload" in config:
+  config["Package-name-dev-noheader-dynload"] = config["Package-name-dev"]
 if not "Package-name-dev-headeronly" in config:
   config["Package-name-dev-headeronly"] = config["Package-name-dev"]
 if not "Package-name-dev-alien" in config:
@@ -260,6 +269,8 @@ if not "Package-name-doc" in config:
   config["Package-name-doc"] = config["package-basename"]+"-doc"
 if not "Install-pattern-lib" in config:
   config["Install-pattern-lib"] = "usr/lib/lib*.so.*"
+if not "Install-pattern-dynload" in config:
+  config["Install-pattern-dynload"] = "usr/lib/lib*.so.*"
 if not "Install-pattern-bin" in config:
   config["Install-pattern-bin"] = "usr/bin/*"
 if not "Install-pattern-python" in config:
@@ -345,6 +356,8 @@ elif "dev-noheader" in hasPackages:
 elif "dev-headeronly" in hasPackages:
   dependencies_dev = config["Dependencies-dev"].split(" ")
 elif "dev-alien" in hasPackages:
+  dependencies_dev = config["Dependencies-dev"].split(" ")
+elif "dev-noheader-dynload" in hasPackages:
   dependencies_dev = config["Dependencies-dev"].split(" ")
 else:
   dependencies_dev = {}
@@ -570,6 +583,8 @@ config["build-depends"] = build_depends
 config["dev-depends"] = dev_depends
 if not "Package-name-lib" in config:
   config["Package-name-lib"] = config["package-basename"]+config["debversion"]
+if not "Package-name-dynload" in config:
+  config["Package-name-dynload"] = config["package-basename"]
 if not "Package-name-bin" in config:
   config["Package-name-bin"] = config["package-basename"]+config["debversion"]
 

--- a/configureRelease
+++ b/configureRelease
@@ -129,6 +129,7 @@ config["Dependencies-bin"] = ""
 config["Dependencies-extra"] = ""
 config["Dependencies-extra2"] = ""
 config["Dependencies-python"] = ""
+config["Dependencies-dynload"] = ""
 config["Install-additional-pattern-dev"] = ""
 
 config["Conflicts-lib"] = ""
@@ -239,6 +240,11 @@ for line in configfile:
 
 # create hasPackages array from space-separated list
 hasPackages = config["Has-packages"].split(" ")
+
+for package in hasPackages:
+  if package.endswith("-dynload"):
+    hasPackages.append("dynload")
+    break
 
 # extend the config by dynamic variables
 if "project" not in config:
@@ -361,6 +367,9 @@ elif "dev-noheader-dynload" in hasPackages:
   dependencies_dev = config["Dependencies-dev"].split(" ")
 else:
   dependencies_dev = {}
+
+if "Use-dynload" in config or "dynload" in hasPackages:
+  dependencies.append("libchimeratk-deviceaccess")
 
 print("Searching for dependencies...")
 
@@ -526,6 +535,28 @@ for dependency in dependencies_dev:
       deps_next_epoch = deps_epoch_split[0] + codename + str( int(deps_epoch_split[1])+1 )
       dev_depends += dependency+" (>= "+deps_epoch+"), " + dependency+" (<< "+deps_next_epoch+"), "
 dev_depends = dev_depends[:-2]
+
+# create dependency for dynload with deviceaccess
+dynload_depends = ""
+if "Use-dynload" in config or "dynload" in hasPackages:
+  dynload_deps_epoch_array = re.findall(
+      "^.*"+codename+"[0-9]*\.", dependency_versions["libchimeratk-deviceaccess"])
+  dynload_deps_epoch = dynload_deps_epoch_array[0][:-1]
+  dynload_deps_epoch_split = dynload_deps_epoch.split(codename)
+  dynload_deps_next_epoch = dynload_deps_epoch_split[0] + \
+      codename + str(int(dynload_deps_epoch_split[1])+1)
+  dynload_depends = "libchimeratk-deviceaccess (>= "+dynload_deps_epoch + \
+      "), libchimeratk-deviceaccess (<< "+dynload_deps_next_epoch+")"
+  if "Use-dynload" in config:
+    package = config["Use-dynload"]
+  else:
+    package = "dynload"
+  if config["Dependencies-" + package] == "":
+    config["Dependencies-" + package] = dynload_depends
+  else:
+    config["Dependencies-" + package] += ", " + dynload_depends
+
+
 
 # determine build number
 print("")

--- a/templates/control.dev-noheader-dynload
+++ b/templates/control.dev-noheader-dynload
@@ -1,0 +1,13 @@
+Package: #Package-name-dev#
+Section: libdevel
+Architecture: #architecture#
+Conflicts: #Conflicts-dev#
+Replaces: #Replaces-dev#
+Breaks: #Breaks-dev#
+Recommends: #Recommends-dev#
+Suggests: #Suggests-dev#
+Enhances: #Enhances-dev#
+Provides: #Provides-dev#
+Depends: #Package-name-dynload#, #dev-depends#
+Description: #Description-dev#
+

--- a/templates/control.dev-noheader-dynload
+++ b/templates/control.dev-noheader-dynload
@@ -8,6 +8,6 @@ Recommends: #Recommends-dev#
 Suggests: #Suggests-dev#
 Enhances: #Enhances-dev#
 Provides: #Provides-dev#
-Depends: #Package-name-dynload#, #dev-depends#
+Depends: #package-basename#, #dev-depends#
 Description: #Description-dev#
 

--- a/templates/control.dynload
+++ b/templates/control.dynload
@@ -9,5 +9,5 @@ Suggests: #Suggests-dynload#
 Enhances: #Enhances-dynload#
 Provides: #Provides-dynload#
 Depends: #Package-name-lib#, #Dependencies-dynload#
-Description: #Description-dynload#
+Description: "Provides the so-file symlink without version number for runtime loading without bringing all the dev package dependencies."
 

--- a/templates/control.dynload
+++ b/templates/control.dynload
@@ -1,0 +1,13 @@
+Package: #package-basename#
+Section: libs
+Architecture: #architecture#
+Conflicts: #Conflicts-dynload#
+Replaces: #Replaces-dynload#
+Breaks: #Breaks-dynload#
+Recommends: #Recommends-dynload#
+Suggests: #Suggests-dynload#
+Enhances: #Enhances-dynload#
+Provides: #Provides-dynload#
+Depends: #Package-name-lib#, #dynload-depends#
+Description: #Description-dynload#
+

--- a/templates/control.dynload
+++ b/templates/control.dynload
@@ -8,6 +8,6 @@ Recommends: #Recommends-dynload#
 Suggests: #Suggests-dynload#
 Enhances: #Enhances-dynload#
 Provides: #Provides-dynload#
-Depends: #Package-name-lib#, #dynload-depends#
+Depends: #Package-name-lib#, #Dependencies-dynload#
 Description: #Description-dynload#
 

--- a/templates/package-dev-noheader-dynload.install
+++ b/templates/package-dev-noheader-dynload.install
@@ -1,0 +1,4 @@
+usr/bin/*-config
+usr/share/cmake*
+usr/share/pkgconfig
+#Install-additional-pattern-dev#

--- a/templates/package-dynload.install
+++ b/templates/package-dynload.install
@@ -1,2 +1,1 @@
 usr/lib/lib*.so
-#Install-pattern-dynload#

--- a/templates/package-dynload.install
+++ b/templates/package-dynload.install
@@ -1,0 +1,2 @@
+usr/lib/lib*.so
+#Install-pattern-dynload#


### PR DESCRIPTION
## Added the dynload functionality for CONFIG files.

### Use case
`libchimeratk-deviceaccess` now has a meta-packge, that does not come with a version number, which is itself dependent of a specific version `libchimeratk-deviceaccess`.

Other packages can depend on this meta package in a specific version and would be updated all together, if the meta-package version is updated. This will ensure consistent package version dependencies across backends, `qthardmon` and the `python3-mtca4upy` bindings.

### Implementation
There are two ways to achieve the new behavior.

If the `CONFIG` has a `dev-noheader` package, it can be exchanged with `dev-noheader-dynload`. This will separate the .so files into an additional package.

For bin and python packages the dependencies for  `libchimeratk-deviceaccess` are automatically added with the correct syntax by adding the line `Use-dynload: bin`  or `Use-dynload: python`

