### PR TITLE
Fix detect libdir

### DIFF
--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -221,7 +221,7 @@ for subpackage in ${config[Has_packages]} ; do
       fi
     
       # check for presence of cmake find package config
-      n_config_files=`dpkg -c $debname | grep "\./usr/lib.*/cmake/${package}/.*\.cmake" | wc -l`
+      n_config_files=`dpkg -c $debname | grep -i "\./usr/lib.*/cmake/${package}/.*\.cmake" | wc -l`
       if [ "$n_config_files" -lt 1 -a $subpackage != "dev-alien" ]; then
         echo "Did not find the cmake find_package config!"
         ERROR=1

--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -163,19 +163,19 @@ for subpackage in ${config[Has_packages]} ; do
   if [ $subpackage == "lib" -a $IS_ALIEN != 1 ]; then
 
     # check for presence of .so file with the right name and version number in the pacakge
-    so_file=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}.so.${so_version}$"`
+    so_file=`dpkg -c $debname | grep -i "\./usr/lib.*/lib${package}.so.${so_version}$"`
     if [ -z "$so_file" ]; then
-      echo "Cannot find the .so file in the library pacakge by the name: ./usr/lib/lib${package}.so.${so_version}"
+      echo "Cannot find the .so file in the library pacakge by the name: ./usr/lib.*/lib${package}.so.${so_version}"
       ERROR=1
     fi
-    so_link=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}.so.${so_version_nopatch} -> lib${package}.so.${so_version}$"`
+    so_link=`dpkg -c $debname | grep -i "\./usr/lib.*/lib${package}.so.${so_version_nopatch} -> lib${package}.so.${so_version}$"`
     if [ -z "$so_link" ]; then
-      echo "Cannot find the link to the .so file in the library pacakge by the name: ./usr/lib/lib${package}.so.${so_version_nopatch}"
+      echo "Cannot find the link to the .so file in the library pacakge by the name: ./usr/lib.*/lib${package}.so.${so_version_nopatch}"
       ERROR=1
     fi
 
     # There should be a debug package as well
-    debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+    debug_files=`dpkg -c $debug_name| grep "\./usr/lib.*/debug/.*\.debug" | wc -l`
     package_increment=2
     echo " -> debug package for subpackage: lib"
     if [ "$debug_files" -lt 1 ]; then
@@ -186,14 +186,14 @@ for subpackage in ${config[Has_packages]} ; do
   elif [ $subpackage == "lib" -a $IS_ALIEN == 1 ]; then
 
     # check for presence of .so file without checking for the exact version
-    so_file=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}.so\..*$"`
+    so_file=`dpkg -c $debname | grep -i "\./usr/lib.*/lib${package}.so\..*$"`
     if [ -z "$so_file" ]; then
-      echo "Cannot find the .so file in the library pacakge by the name: ./usr/lib/lib*.so.*"
+      echo "Cannot find the .so file in the library pacakge by the name: ./usr/lib.*/lib*.so.*"
       ERROR=1
     fi
 
     # There should be a debug package as well
-    debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+    debug_files=`dpkg -c $debug_name| grep "\./usr/lib.*/debug/.*\.debug" | wc -l`
     package_increment=2
     echo " -> debug package for subpackage: lib"
     if [ "$debug_files" -lt 1 ]; then
@@ -220,28 +220,28 @@ for subpackage in ${config[Has_packages]} ; do
         ERROR=1
       fi
     
-      # check for presence of cmake find package macro
-      n_config_files=`dpkg -c $debname | grep "\./usr/share/cmake-.*/Modules/Find.*\.cmake" | wc -l`
+      # check for presence of cmake find package config
+      n_config_files=`dpkg -c $debname | grep "\./usr/lib.*/cmake/${package}/.*\.cmake" | wc -l`
       if [ "$n_config_files" -lt 1 -a $subpackage != "dev-alien" ]; then
-        echo "Did not find the cmake find_package macro!"
+        echo "Did not find the cmake find_package config!"
         ERROR=1
       fi
     fi
 
     # check for presence of so link
     if [ $subpackage == "dev" -o $subpackage == "dev-noheader" -o $subpackage == "dynload" ]; then
-      so_link=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}\.so -> lib${package}\.so\.${so_version_nopatch}$"`
+      so_link=`dpkg -c $debname | grep -i "\./usr/lib.*/lib${package}\.so -> lib${package}\.so\.${so_version_nopatch}$"`
       if [ -z "$so_link" ]; then
-        echo "Cannot find the link to the .so file in the dev pacakge by the name: ./usr/lib/lib${package}.so"
+        echo "Cannot find the link to the .so file in the dev pacakge by the name: ./usr/lib.*/lib${package}.so"
         ERROR=1
       fi
     fi
     
     # check for presence of so link in alien package - do not check for exact target
     if [ $subpackage == "dev-alien" ]; then
-      so_link=`dpkg -c $debname | grep -i "\./usr/lib/lib${package}\.so -> lib${package}\.so\..*$"`
+      so_link=`dpkg -c $debname | grep -i "\./usr/lib.*/lib${package}\.so -> lib${package}\.so\..*$"`
       if [ -z "$so_link" ]; then
-        echo "Cannot find the link to the .so file in the dev pacakge by the name: ./usr/lib/lib${package}.so"
+        echo "Cannot find the link to the .so file in the dev pacakge by the name: ./usr/lib.*/lib${package}.so"
         ERROR=1
       fi
     fi
@@ -327,7 +327,7 @@ for subpackage in ${config[Has_packages]} ; do
 
     # Bin packages may or may not have a debug package (could contain only scripts). If it has one, check for consistency
     if [ -e "$debug_name" ] ; then
-      debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+      debug_files=`dpkg -c $debug_name| grep "\./usr/lib.*/debug/.*\.debug" | wc -l`
       package_increment=2
       echo " -> debug package for subpackage: bin"
       if [ "$debug_files" -lt 1 ]; then
@@ -354,7 +354,7 @@ for subpackage in ${config[Has_packages]} ; do
 
     # May or may not have a debug package. If it has one, check for consistency
     if [ -e "$debug_name" ] ; then
-      debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+      debug_files=`dpkg -c $debug_name| grep "\./usr/lib.*/debug/.*\.debug" | wc -l`
       package_increment=2
       echo " -> debug package for subpackage: $subpackage"
       if [ "$debug_files" -lt 1 ]; then
@@ -385,7 +385,7 @@ for subpackage in ${config[Has_packages]} ; do
       echo " -> debug package for subpackage: python"
 
       # There should be a debug package as well
-      debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+      debug_files=`dpkg -c $debug_name| grep "\./usr/lib.*/debug/.*\.debug" | wc -l`
       if [ "$debug_files" -lt 1 ]; then
         echo "Debug package for python package is empty!"
         ERROR=1
@@ -402,7 +402,7 @@ for subpackage in ${config[Has_packages]} ; do
     fi
 
     # There should be a debug package as well
-    debug_files=`dpkg -c $debug_name| grep "\./usr/lib/debug/.*\.debug" | wc -l`
+    debug_files=`dpkg -c $debug_name| grep "\./usr/lib.*/debug/.*\.debug" | wc -l`
     package_increment=2
     echo " -> debug package for subpackage: doocs-bin"
     if [ "$debug_files" -lt 1 ]; then

--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -217,10 +217,10 @@ for subpackage in ${config[Has_packages]} ; do
     fi
 
     if [ $subpackage != "dynload" ]; then
-      # check for presence of -config script
-      n_config_files=`dpkg -c $debname | grep "\./usr/bin/.*-config" | wc -l`
+      # check for presence pkgconfig
+      n_config_files=`dpkg -c $debname | grep "\./usr/share/pkgconfig/.*\.pc" | wc -l`
       if [ "$n_config_files" -ne 1 -a $subpackage != "dev-alien" -a $subpackage != "dev-alien-headeronly" ]; then
-        echo "Did not find the config script required for a dev package!"
+        echo "Did not find the pkgconfig required for a dev package!"
         ERROR=1
       fi
     

--- a/checkPackageConsistency
+++ b/checkPackageConsistency
@@ -220,7 +220,7 @@ for subpackage in ${config[Has_packages]} ; do
         ERROR=1
       fi
     
-      # check for presence of cmake find package config
+      # check for presence of cmake package config
       n_config_files=`dpkg -c $debname | grep -i "\./usr/lib.*/cmake/${package}/.*\.cmake" | wc -l`
       if [ "$n_config_files" -lt 1 -a $subpackage != "dev-alien" ]; then
         echo "Did not find the cmake find_package config!"

--- a/configureRelease
+++ b/configureRelease
@@ -273,10 +273,11 @@ if not "Package-name-dev-alien" in config:
   config["Package-name-dev-alien"] = config["Package-name-dev"]
 if not "Package-name-doc" in config:
   config["Package-name-doc"] = config["package-basename"]+"-doc"
+# @LIBDIR@ will be replaced in a later step, by detect_libdir.sh, after build;install steps
 if not "Install-pattern-lib" in config:
-  config["Install-pattern-lib"] = "usr/lib/x86_64-linux-gnu/lib*.so.*"
+  config["Install-pattern-lib"] = "@LIBDIR@/lib*.so.*"
 if not "Install-pattern-dynload" in config:
-  config["Install-pattern-dynload"] = "usr/lib/x86_64-linux-gnu/lib*.so.*"
+  config["Install-pattern-dynload"] = "@LIBDIR@/lib*.so.*"
 if not "Install-pattern-bin" in config:
   config["Install-pattern-bin"] = "usr/bin/*"
 if not "Install-pattern-python" in config:
@@ -671,7 +672,7 @@ if not os.path.isdir(controldir+"/source"):
   os.makedirs(controldir+"/source")
 
 # list of files to be processed (static part)
-filelist = [ "makeDebianPackage.config", "compat", "rules", "source/format", "control.src" ]
+filelist = [ "makeDebianPackage.config", "compat", "rules", "detect_libdir.sh", "source/format", "control.src" ]
 
 # List of files to be processed for each package
 # If there is a single package only, no install file is needed and everything gets included in the package. Otherwise
@@ -760,6 +761,7 @@ if "lib" in hasPackages:
 
 # make rules file executable
 subprocess.call(["chmod", "+x", controldir+"/rules"])
+subprocess.call(["chmod", "+x", controldir+"/detect_libdir.sh"])
 
 # copy preinst, postinst, prerm and postrm scripts if existent
 if os.path.isfile("DebianBuildVersions/"+project+"/preinst"):

--- a/configureRelease
+++ b/configureRelease
@@ -274,9 +274,9 @@ if not "Package-name-dev-alien" in config:
 if not "Package-name-doc" in config:
   config["Package-name-doc"] = config["package-basename"]+"-doc"
 if not "Install-pattern-lib" in config:
-  config["Install-pattern-lib"] = "usr/lib/lib*.so.*"
+  config["Install-pattern-lib"] = "usr/lib/x86_64-linux-gnu/lib*.so.*"
 if not "Install-pattern-dynload" in config:
-  config["Install-pattern-dynload"] = "usr/lib/lib*.so.*"
+  config["Install-pattern-dynload"] = "usr/lib/x86_64-linux-gnu/lib*.so.*"
 if not "Install-pattern-bin" in config:
   config["Install-pattern-bin"] = "usr/bin/*"
 if not "Install-pattern-python" in config:

--- a/templates/detect_libdir.sh
+++ b/templates/detect_libdir.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+BUILDDIR=debian/tmp
+INSTFILEDIR=debian
+
+echo "detect_libdir: build dir contents"
+find ${BUILDDIR}
+
+# detect libdir used by package's build;install command.
+# It should be either /usr/lib or /usr/lib/x86_64-linux-gnu.
+# For non-lib packages, where neither is used in output, result variable LIBDIR will be empty
+LIBDIR=
+c=`find ${BUILDDIR} -wholename '*/usr/lib/x86_64-linux-gnu/*' -print -quit | wc -l`
+if [ $c -gt 0 ]; then
+    LIBDIR=/usr/lib/x86_64-linux-gnu
+else
+    c=`find ${BUILDDIR} -wholename '*/usr/lib/*' -print -quit | wc -l`
+    if [ $c -gt 0 ]; then
+        LIBDIR=/usr/lib
+    fi
+fi
+
+# replace @LIBDIR@ in install-lists
+for f in ${INSTFILEDIR}/*.install; do
+    tf=`tempfile`
+    cat $f | sed "s|@LIBDIR@|${LIBDIR}|g" > ${tf}
+    mv ${tf} $f
+done
+
+

--- a/templates/detect_libdir.sh
+++ b/templates/detect_libdir.sh
@@ -21,9 +21,7 @@ fi
 
 # replace @LIBDIR@ in install-lists
 for f in ${INSTFILEDIR}/*.install; do
-    tf=`tempfile`
-    cat $f | sed "s|@LIBDIR@|${LIBDIR}|g" > ${tf}
-    mv ${tf} $f
+    sed -e "s|@LIBDIR@|${LIBDIR}|g" -i $f
 done
 
 

--- a/templates/package-dev-alien.install
+++ b/templates/package-dev-alien.install
@@ -1,3 +1,3 @@
-usr/lib/x86_64-linux-gnu/lib*.so
+@LIBDIR@/lib*.so
 usr/include/*
 #Install-additional-pattern-dev#

--- a/templates/package-dev-alien.install
+++ b/templates/package-dev-alien.install
@@ -1,3 +1,3 @@
-usr/lib/lib*.so
+usr/lib/x86_64-linux-gnu/lib*.so
 usr/include/*
 #Install-additional-pattern-dev#

--- a/templates/package-dev-headeronly.install
+++ b/templates/package-dev-headeronly.install
@@ -1,5 +1,5 @@
 usr/bin/*-config
 usr/include/*
-usr/lib/x86_64-linux-gnu/cmake/#project#/*
+@LIBDIR@/cmake/#project#/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-headeronly.install
+++ b/templates/package-dev-headeronly.install
@@ -1,5 +1,5 @@
 usr/bin/*-config
 usr/include/*
-@LIBDIR@/cmake/#project#/*
+@LIBDIR@/cmake/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-headeronly.install
+++ b/templates/package-dev-headeronly.install
@@ -1,5 +1,5 @@
 usr/bin/*-config
 usr/include/*
-usr/share/cmake*
+usr/lib/x86_64-linux-gnu/cmake/#project#/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader-dynload.install
+++ b/templates/package-dev-noheader-dynload.install
@@ -1,4 +1,4 @@
 usr/bin/*-config
-@LIBDIR@/cmake/#project#
+@LIBDIR@/cmake/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader-dynload.install
+++ b/templates/package-dev-noheader-dynload.install
@@ -1,4 +1,4 @@
 usr/bin/*-config
-usr/lib/x86_64-linux-gnu/cmake/#project#
+@LIBDIR@/cmake/#project#
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader-dynload.install
+++ b/templates/package-dev-noheader-dynload.install
@@ -1,4 +1,4 @@
 usr/bin/*-config
-usr/share/cmake*
+usr/lib/x86_64-linux-gnu/cmake/#project#
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader.install
+++ b/templates/package-dev-noheader.install
@@ -1,5 +1,5 @@
 usr/bin/*-config
-usr/lib/lib*.so
-usr/share/cmake*
+usr/lib/x86_64-linux-gnu/lib*.so
+usr/lib/x86_64-linux-gnu/cmake/#project#
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader.install
+++ b/templates/package-dev-noheader.install
@@ -1,5 +1,5 @@
 usr/bin/*-config
-usr/lib/x86_64-linux-gnu/lib*.so
-usr/lib/x86_64-linux-gnu/cmake/#project#
+@LIBDIR@/lib*.so
+@LIBDIR@/cmake/#project#
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader.install
+++ b/templates/package-dev-noheader.install
@@ -1,5 +1,5 @@
 usr/bin/*-config
 @LIBDIR@/lib*.so
-@LIBDIR@/cmake/#project#
+@LIBDIR@/cmake/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev.install
+++ b/templates/package-dev.install
@@ -1,6 +1,6 @@
 usr/bin/*-config
-usr/lib/x86_64-linux-gnu/lib*.so
-usr/lib/x86_64-linux-gnu/cmake/#project#
+@LIBDIR@/lib*.so
+@LIBDIR@/cmake/#project#
 usr/include/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev.install
+++ b/templates/package-dev.install
@@ -1,6 +1,6 @@
 usr/bin/*-config
 @LIBDIR@/lib*.so
-@LIBDIR@/cmake/#project#
+@LIBDIR@/cmake/*
 usr/include/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-doc.install
+++ b/templates/package-doc.install
@@ -1,1 +1,1 @@
-usr/share/doc/#project#*/* usr/share/doc/#package-basename##debversion#
+usr/share/doc/*/* usr/share/doc/#package-basename##debversion#

--- a/templates/package-dynload.install
+++ b/templates/package-dynload.install
@@ -1,1 +1,1 @@
-usr/lib/x86_64-linux-gnu/lib*.so
+@LIBDIR@/lib*.so

--- a/templates/package-dynload.install
+++ b/templates/package-dynload.install
@@ -1,1 +1,1 @@
-usr/lib/lib*.so
+usr/lib/x86_64-linux-gnu/lib*.so

--- a/templates/package-olddev.install
+++ b/templates/package-olddev.install
@@ -1,6 +1,0 @@
-usr/bin/*-config
-usr/lib/lib*.so
-usr/include/*
-usr/share/cmake*
-usr/share/pkgconfig
-#Install-additional-pattern-dev#

--- a/templates/package-olddev.install
+++ b/templates/package-olddev.install
@@ -1,6 +1,6 @@
 usr/bin/*-config
-usr/lib/x86_64-linux-gnu/lib*.so
-usr/lib/x86_64-linux-gnu/cmake/#project#
+usr/lib/lib*.so
 usr/include/*
+usr/share/cmake*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/rules
+++ b/templates/rules
@@ -11,3 +11,6 @@ include /usr/share/dpkg/default.mk
 %:
 	dh $@ --parallel
 
+override_dh_install:
+	./debian/detect_libdir.sh
+	dh_install


### PR DESCRIPTION
has been tested to work with cppext 1.05 and DeviceAccess 1.09 (both not yet tagged officially), plus latest of automatically detected reverse-dependencies (those are pre-cmake-modernize versions)