### PR TITLE
build more reverse-deps of DeviceAccess

### DIFF
--- a/master
+++ b/master
@@ -237,6 +237,11 @@ for package in "${!package_list[@]}"; do
   # (Cannot use 'set -o pipefail', as that would break other stuff in this script)
   DEPENDENCIES_RESULT=$(./findReverseDependencies lib${package}-dev $distribution $DebianRepository $arch)
   echo "${DEPENDENCIES_RESULT}" | grep "^lib" | grep -- "-dev " | sed -e 's/^lib//' -e 's/-dev / /' > $TEMPFILE
+  # DeviceAccess is special case: also build all packages depending on 'libchimeratk-deviceaccess', not just libs but also e.g qthardmon
+  if [ ${package} = "chimeratk-deviceaccess" ]; then
+    DEPENDENCIES_RESULT2=$(./findReverseDependencies lib${package}$ $distribution $DebianRepository $arch)
+    echo "${DEPENDENCIES_RESULT2}" | grep -v -- "-dbgsym " | sed -e 's/^lib//' -e 's/-dev / /' >> $TEMPFILE
+  fi
   readarray revdeps_with_versions < $TEMPFILE
   rm -f $TEMPFILE
   # loop over any found reverse dependencies


### PR DESCRIPTION
special case: packages depending on meta-package chimeratk-deviceaccess must also be rebuilt automatically