### PR TITLE
handle single-package case correctly

### DIFF
--- a/templates/detect_libdir.sh
+++ b/templates/detect_libdir.sh
@@ -1,19 +1,29 @@
 #!/bin/bash
-BUILDDIR=debian/tmp
+
+# dh_auto_install: default for DESTDIR is debian/tmp (multi-package case) or debian/<package> (single-package case)
+# -> auto-detect the case.
+# in the single-package case, nothing needs to be done, no need to sort files into different packages, in fact even *.install files are not there.
+INSTALLDIR=debian/tmp
+if [ ! -d ${INSTALLDIR} ]; then
+    echo "detect_libdir: nothing to do"
+    exit 0
+fi
+
+# directory with *.install lists
 INSTFILEDIR=debian
 
-echo "detect_libdir: build dir contents"
-find ${BUILDDIR}
+echo "detect_libdir: install dir contents:"
+find ${INSTALLDIR}
 
 # detect libdir used by package's build;install command.
 # It should be either /usr/lib or /usr/lib/x86_64-linux-gnu.
 # For non-lib packages, where neither is used in output, result variable LIBDIR will be empty
 LIBDIR=
-c=`find ${BUILDDIR} -wholename '*/usr/lib/x86_64-linux-gnu/*' -print -quit | wc -l`
+c=`find ${INSTALLDIR} -wholename '*/usr/lib/x86_64-linux-gnu/*' -print -quit | wc -l`
 if [ $c -gt 0 ]; then
     LIBDIR=/usr/lib/x86_64-linux-gnu
 else
-    c=`find ${BUILDDIR} -wholename '*/usr/lib/*' -print -quit | wc -l`
+    c=`find ${INSTALLDIR} -wholename '*/usr/lib/*' -print -quit | wc -l`
     if [ $c -gt 0 ]; then
         LIBDIR=/usr/lib
     fi


### PR DESCRIPTION
in that case, no need to sort files into different packages, and detect_libdir.sh should do nothing