### PR TITLE
feat: warn if virtual package with version as dependency

### DIFF
--- a/configureRelease
+++ b/configureRelease
@@ -78,6 +78,12 @@ def resolveDeps(dependencies, filename):
           if not dependency in dependency_versions.keys() or parseVersion(PackageAsDictionary["Version"]) > parseVersion(dependency_versions[dependency]):
             dependency_versions[dependency] = PackageAsDictionary["Version"]
             map_virtual_to_real[dependency] = PackageAsDictionary["Package"]
+        elif dependency in [name.strip().split(' ')[0] for name in PackageAsDictionary["Provides"].split(',') ]:
+          print('NOTE: Dependency "'+dependency+'" found as virtual package provided by "'+PackageAsDictionary["Package"]+
+                '", but the Provides statement has a version number. This is currently unsupported by the configureRelease '+
+                'script, hence this package is ignored. Check source code for more details.')
+          # This could be implemented by using the version number from the Provides statement for selecting the latest package
+          # providing the dependency. Since there is no use case at the time of writing this is not yet implemented.
 
   return (dependency_versions, map_virtual_to_real)
 


### PR DESCRIPTION
This is currently not implemented and the package just gets ignored, but since there is no use case for now the implementation is postponed.