### PR TITLE
fix: Dev package depends on exact version of link

### DIFF
--- a/templates/control.dev-noheader-dynload
+++ b/templates/control.dev-noheader-dynload
@@ -8,6 +8,6 @@ Recommends: #Recommends-dev#
 Suggests: #Suggests-dev#
 Enhances: #Enhances-dev#
 Provides: #Provides-dev#
-Depends: #package-basename#, #dev-depends#
+Depends: #package-basename# (= #package-version#), #dev-depends#
 Description: #Description-dev#
 


### PR DESCRIPTION
Otherwise an update of the dev package will not pull in the new symlink
package but will be happy with the currently installed and most likekly
incompatible .so symlink from the old package
