### PR TITLE
fix: Force Debian if codename is from Debian

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -42,10 +42,12 @@ DEBIANREPOSITORY="${DebianRepository}"
 
 # List of mirrors / package repositories used inside the pbuilder environment by apt
 MIRRORLIST="deb [trusted=yes] file://${LOCAL_REPOS} ${distribution} main|deb [trusted=yes] ${DEBIANREPOSITORY}/pub/doocs ${distribution} main|deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-updates main universe|deb http://de.archive.ubuntu.com/ubuntu/ ${distribution}-security main universe"
+MIRROR="http://de.archive.ubuntu.com/ubuntu"
 ADDITIONALREPO="universe"
-if [ "${distribution}" == "buster" ] || [ "${distribution}" == "stretch"  ]; then
+if [ "${distribution}" == "buster" ] || [ "${distribution}" == "stretch"  ] || [ "${distribution}" == "bullseye" ] || [ "${distribution}" == "bookworm" ]; then
 	MIRRORLIST="deb [trusted=yes] file://${LOCAL_REPOS} ${distribution} main|deb [trusted=yes] ${DEBIANREPOSITORY}/pub/doocs ${distribution} main|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution}-backports main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution} main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian-security ${distribution}/updates main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution}-updates main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/extra/desy ${distribution} desy|deb [trusted=yes] ${DesyNimsRepo}/extra/hasylab.debian ${distribution} main non-free contrib"
 	ADDITIONALREPO="contrib"
+    MIRROR="http://ftp.de.debian.org/debian"
 fi
 
 # This list is used when the pbuilder image is build the first time. 

--- a/config.sh
+++ b/config.sh
@@ -45,7 +45,7 @@ MIRRORLIST="deb [trusted=yes] file://${LOCAL_REPOS} ${distribution} main|deb [tr
 MIRROR="http://de.archive.ubuntu.com/ubuntu"
 ADDITIONALREPO="universe"
 if [ "${distribution}" == "buster" ] || [ "${distribution}" == "stretch"  ] || [ "${distribution}" == "bullseye" ] || [ "${distribution}" == "bookworm" ]; then
-	MIRRORLIST="deb [trusted=yes] file://${LOCAL_REPOS} ${distribution} main|deb [trusted=yes] ${DEBIANREPOSITORY}/pub/doocs ${distribution} main|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution}-backports main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution} main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian-security ${distribution}/updates main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution}-updates main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/extra/desy ${distribution} desy|deb [trusted=yes] ${DesyNimsRepo}/extra/hasylab.debian ${distribution} main non-free contrib"
+	MIRRORLIST="deb [trusted=yes] file://${LOCAL_REPOS} ${distribution} main|deb [trusted=yes] ${DEBIANREPOSITORY}/pub/doocs ${distribution} main|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution}-backports main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution} main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian-security ${distribution}-security/updates main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/debian ${distribution}-updates main contrib non-free|deb [trusted=yes] ${DesyNimsRepo}/extra/desy ${distribution} desy|deb [trusted=yes] ${DesyNimsRepo}/extra/hasylab.debian ${distribution} main non-free contrib"
 	ADDITIONALREPO="contrib"
     MIRROR="http://ftp.de.debian.org/debian"
 fi

--- a/updatePBuilder
+++ b/updatePBuilder
@@ -39,7 +39,7 @@ mkdir -p "${LOCAL_REPOS}"
 
 # if image does not exist, create it first
 if [ ! -f ${PBUILDER_IMAGE} ]; then
-  sudo pbuilder --create --distribution $DISTRIBUTION --basetgz "${PBUILDER_IMAGE}" --extrapackages "${INITIALPACKAGESLIST}" --basetgz "${PBUILDER_IMAGE}" --othermirror "${INITIALEXTRAMIRROR}"|| exit 1
+  sudo pbuilder --create --distribution $DISTRIBUTION --mirror ${MIRROR} --basetgz "${PBUILDER_IMAGE}" --extrapackages "${INITIALPACKAGESLIST}" --basetgz "${PBUILDER_IMAGE}" --othermirror "${INITIALEXTRAMIRROR}"|| exit 1
 
   # Execute a script inside the pbuilder chroot environment to set it up properly for our needs:
   # - Make sure the local package repository gets priority. Not sure how this works and if it's realy correct. Found
@@ -69,6 +69,7 @@ ${WD}/updateLocalRepos
 # update the pbuilder chroot environment
 sudo pbuilder --update                                                                                                \
               --distribution ${DISTRIBUTION}                                                                          \
+              --mirror ${MIRROR}                                                                                      \
               --override-config                                                                                       \
               --components "main ${ADDITIONALREPO}"                                                                            \
               --othermirror "${MIRRORLIST}"                                                                           \


### PR DESCRIPTION
Otherwise pbuilder will try to bootstrap the image from the ubuntu
repository which fails obviously
