### PR TITLE
fix: Add a hook that calls apt update

### DIFF
--- a/pbuilder-hooks/H10update
+++ b/pbuilder-hooks/H10update
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+apt update


### PR DESCRIPTION
Not sure why this is necessary, but otherwise the verification step
cannot install anything.
