### PR TITLE
fix: running updatePBuilder stand-alone

### DIFF
--- a/updatePBuilder
+++ b/updatePBuilder
@@ -3,7 +3,7 @@
 # Shell script to create or update the pbuilder image used in makeDebianPackage
 
 # create directory holding pbuilder images
-WD=`realpath $(dirname "$0")`
+WD=$(realpath "$(dirname "$0")")
 mkdir -p "${WD}/pbuilder-base"
 
 # Parse command line arguments
@@ -28,50 +28,57 @@ else
 fi
 
 # load configuration
-source ${WD}/config.sh
+# shellcheck disable=SC1091
+source "${WD}/config.sh"
 
 # form the file name of the image
 PBUILDER_IMAGE="${WD}/pbuilder-base/base-${DISTRIBUTION}.tgz"
 
 # build the mirror list including the local repository
 LOCAL_REPOS=${WD}/pbuilder-result
-mkdir -p "${LOCAL_REPOS}"
+mkdir -p "${LOCAL_REPOS}/dists/${DISTRIBUTION}/main/binary-amd64"
+touch "${LOCAL_REPOS}/dists/${DISTRIBUTION}/main/binary-amd64/Packages"
 
 # if image does not exist, create it first
-if [ ! -f ${PBUILDER_IMAGE} ]; then
-  sudo pbuilder --create --distribution $DISTRIBUTION --mirror ${MIRROR} --basetgz "${PBUILDER_IMAGE}" --extrapackages "${INITIALPACKAGESLIST}" --basetgz "${PBUILDER_IMAGE}" --othermirror "${INITIALEXTRAMIRROR}"|| exit 1
+if [ ! -f "${PBUILDER_IMAGE}" ]; then
+  sudo pbuilder --create --distribution "$DISTRIBUTION" --mirror "${MIRROR}" --basetgz "${PBUILDER_IMAGE}" --extrapackages "${INITIALPACKAGESLIST}" --basetgz "${PBUILDER_IMAGE}" --othermirror "${INITIALEXTRAMIRROR}"|| exit 1
 
   # Execute a script inside the pbuilder chroot environment to set it up properly for our needs:
   # - Make sure the local package repository gets priority. Not sure how this works and if it's realy correct. Found
   #   this solution here: http://askubuntu.com/questions/135339/assign-highest-priority-to-my-local-repository
   # - Also fix the problem that /run/shm is a symlink to /dev/shm and will be incorrectly mounted by pbuilder.
   # - add the user doocsadm which is needed for the doocs server packages (and their postinst scripts)
-  SCRIPT=`mktemp -p ${LOCAL_REPOS}`  # must be in the pbuilder-result directory, since it is bind-mounted in the pbuilder environment
-  echo "#!/bin/bash -e" > $SCRIPT
-  echo "echo 'APT { Get { AllowUnauthenticated \"1\"; }; };'>/etc/apt/apt.conf.d/99allow_unauth" >> $SCRIPT # fix for debian to allow apt repos without signature
-  echo "echo 'Package: *' > /etc/apt/preferences" >> $SCRIPT
-  echo "echo 'Pin: origin \"\"' >> /etc/apt/preferences" >> $SCRIPT
-  echo "echo 'Pin-Priority: 1001' >> /etc/apt/preferences" >> $SCRIPT
-  echo "if [ -L /run/shm ]; then" >> $SCRIPT
-  echo "  rm /run/shm" >> $SCRIPT
-  echo "  mkdir /run/shm" >> $SCRIPT
-  echo "fi" >> $SCRIPT
-  echo "groupadd doocsadm" >> $SCRIPT
-  echo "useradd -m -g doocsadm doocsadm" >> $SCRIPT
-  sudo pbuilder --execute --distribution ${distribution} --override-config --components "main ${ADDITIONALREPO}" \
-                --othermirror "${MIRRORLIST}"  --save-after-exec                                        \
+  SCRIPT=$(mktemp -p "${LOCAL_REPOS}")  # must be in the pbuilder-result directory, since it is bind-mounted in the pbuilder environment
+  cat > "$SCRIPT" <<EOF
+#!/bin/bash -e
+# fix for debian to allow apt repos without signature:
+echo 'APT { Get { AllowUnauthenticated "1"; }; };'>/etc/apt/apt.conf.d/99allow_unauth
+echo 'Package: *' > /etc/apt/preferences
+echo 'Pin: origin ""' >> /etc/apt/preferences
+echo 'Pin-Priority: 1001' >> /etc/apt/preferences
+if [ -L /run/shm ]; then
+  rm /run/shm
+  mkdir /run/shm
+fi
+groupadd doocsadm
+useradd -m -g doocsadm doocsadm
+EOF
+  sudo pbuilder --execute --distribution "${DISTRIBUTION}" --override-config --components "main ${ADDITIONALREPO}"    \
+                --othermirror "${MIRRORLIST}"  --save-after-exec                                                      \
                 --basetgz "${PBUILDER_IMAGE}" --bindmounts "${LOCAL_REPOS}" "${SCRIPT}"
 fi
 
-# update
-${WD}/updateLocalRepos
+# update local repositories, if build process on-going
+if [ -f "${WD}/master-control" ]; then
+  "${WD}/updateLocalRepos"
+fi
 
 # update the pbuilder chroot environment
 sudo pbuilder --update                                                                                                \
-              --distribution ${DISTRIBUTION}                                                                          \
-              --mirror ${MIRROR}                                                                                      \
+              --distribution "${DISTRIBUTION}"                                                                        \
+              --mirror "${MIRROR}"                                                                                    \
               --override-config                                                                                       \
-              --components "main ${ADDITIONALREPO}"                                                                            \
+              --components "main ${ADDITIONALREPO}"                                                                   \
               --othermirror "${MIRRORLIST}"                                                                           \
               --hookdir "${WD}/pbuilder-hooks"                                                                        \
               --basetgz "${PBUILDER_IMAGE}"                                                                           \


### PR DESCRIPTION
Also fixed most shellcheck warnings, some of them actually seemt to
prevent it from working with the --setup option resp. without an
existing image.