### PR TITLE
fix: remove config scripts from install pattern

### DIFF
--- a/templates/package-dev-headeronly.install
+++ b/templates/package-dev-headeronly.install
@@ -1,4 +1,3 @@
-usr/bin/*-config
 usr/include/*
 @LIBDIR@/cmake/*
 usr/share/pkgconfig

--- a/templates/package-dev-noheader-dynload.install
+++ b/templates/package-dev-noheader-dynload.install
@@ -1,4 +1,3 @@
-usr/bin/*-config
 @LIBDIR@/cmake/*
 usr/share/pkgconfig
 #Install-additional-pattern-dev#

--- a/templates/package-dev-noheader.install
+++ b/templates/package-dev-noheader.install
@@ -1,4 +1,3 @@
-usr/bin/*-config
 @LIBDIR@/lib*.so
 @LIBDIR@/cmake/*
 usr/share/pkgconfig

--- a/templates/package-dev.install
+++ b/templates/package-dev.install
@@ -1,4 +1,3 @@
-usr/bin/*-config
 @LIBDIR@/lib*.so
 @LIBDIR@/cmake/*
 usr/include/*


### PR DESCRIPTION
The compatibitiy layer with the shell script configurations for the libraries has been removed from the project template. Install was failing because the files in the install pattern were no longer there.
